### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @puppetlabs/compliance


### PR DESCRIPTION
Creating this file so this repo doesn't get archived.

This repo is referenced from puppetlabs/cloud-discovery & puppetlabs/ps-blanket both of which are key components of Remediate. Remediate is no longer being developed and many of the maintainers have moved to the Compliance team so setting code owner to @puppetlabs/compliance 

If there's a more appropriate (or more accurate) team then let me know please https://github.com/orgs/puppetlabs/teams
